### PR TITLE
投稿作成・編集フォームの改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 gem 'devise'
 gem 'aws-sdk-s3', require: false
+gem 'rinku'
 
 group :production do
   gem 'rails_12factor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.4)
+    rinku (2.0.6)
     rubocop (0.90.0)
       parallel (~> 1.10)
       parser (>= 2.7.1.1)
@@ -283,6 +284,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 6.0.0)
   rails_12factor
+  rinku
   rubocop
   sass-rails (~> 5)
   selenium-webdriver

--- a/app/assets/stylesheets/posts/show.css
+++ b/app/assets/stylesheets/posts/show.css
@@ -28,3 +28,8 @@
   width: 12vw;
   position: relative;
 }
+
+.show-container-element {
+  padding-bottom: 2vh;
+  text-align: left;
+}

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -59,7 +59,7 @@
     <%# 投稿ボタン %>
     <div class="post-submit">
       <%= f.submit "更新する", class:"post-btn" %>
-      <%= link_to 'もどる', root_path, class:"back-btn" %>
+      <%= link_to 'もどる', :back, class:"back-btn" %>
     </div>
     <%# 投稿ボタン %>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,10 +27,10 @@
       <%= image_tag @post.ref_img.variant(resize:'500x500'), class:"show-ref-img" if @post.ref_img.attached? %>
     </div>
     <div class="show-container-element">
-      <%= safe_join(@post.content.split("\n"),tag(:br)) %>
+      <%= raw Rinku.auto_link(safe_join(@post.content.split("\n"),tag(:br))) %>
     </div>
     <div class="show-container-element">
-      <%= safe_join(@post.ref_url.split("\n"),tag(:br)) %>
+      <%= raw Rinku.auto_link(safe_join(@post.ref_url.split("\n"),tag(:br))) %>
     </div>
   </div>
   <div class="back-to-top">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -26,11 +26,11 @@
     <div>
       <%= image_tag @post.ref_img.variant(resize:'500x500'), class:"show-ref-img" if @post.ref_img.attached? %>
     </div>
-    <div class="show-content">
-      <%= @post.content %>
+    <div class="show-container-element">
+      <%= safe_join(@post.content.split("\n"),tag(:br)) %>
     </div>
-    <div class="show-ref-url">
-      <%= @post.ref_url %>
+    <div class="show-container-element">
+      <%= safe_join(@post.ref_url.split("\n"),tag(:br)) %>
     </div>
   </div>
   <div class="back-to-top">


### PR DESCRIPTION
# What
投稿作成・編集フォームの改善
# Why
投稿詳細画面におけるテキストの左揃えと改行を設定するため
テキスト内にURLが含まれている場合、自動でリンクにするため
トップページもしくは詳細画面から編集画面に遷移し、戻るボタンをクリックした時、それぞれ直前のページに戻る設定をするため